### PR TITLE
Update JSBSim to v0.99.60

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "JSBSim" %}
-{% set version = "1.1.5" %}
+{% set version = "0.99.60" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9a5f7da9ee8a2374d8e9d9141492b5dd97c86d1bab7521dc4c62b727becb2f7a
+  sha256: 921fdd460881f2fcf262b3b81f1e1fa90676edde34ff7543bf0dc4e24712e849
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<36]
   script: "{{ PYTHON }} -m pip install . -vv"
 


### PR DESCRIPTION
New JSBSim release v0.99.60
- Auto-generated by [JSBSim-Team/jsbsim](https://github.com/JSBSim-Team/jsbsim)